### PR TITLE
Add enhanced owner workflow, file uploads, and active filters

### DIFF
--- a/mascotas/App/Controllers/Mascotas/Mascotas.php
+++ b/mascotas/App/Controllers/Mascotas/Mascotas.php
@@ -107,36 +107,76 @@ class Mascotas extends BaseController
             return json_encode(Danger('No posees permisos para realizar esa acción')->toArray());
         }
 
-        $ID_PERSONA     = trim($_POST['ID_PERSONA']     ?? '');
-        $NOMBRE_MASCOTA = trim($_POST['NOMBRE_MASCOTA'] ?? '');
-        $FOTO_URL       = trim($_POST['FOTO_URL']       ?? '');
+        $ID_PERSONA      = trim($_POST['ID_PERSONA']      ?? '');
+        $NOMBRE_MASCOTA  = trim($_POST['NOMBRE_MASCOTA']  ?? '');
+        $FOTO_URL        = trim($_POST['FOTO_URL']        ?? '');
+        $FOTO_ACTUAL     = trim($_POST['FOTO_ACTUAL']     ?? '');
+        $NOMBRE_DUENNO   = trim($_POST['NOMBRE_DUENNO']   ?? '');
+        $TELEFONO_DUENNO = trim($_POST['TELEFONO_DUENNO'] ?? '');
+        $CORREO_DUENNO   = trim($_POST['CORREO_DUENNO']   ?? '');
 
         if ($ID_PERSONA === '' || $NOMBRE_MASCOTA === '') {
             return json_encode(Warning('Cédula del dueño y Nombre de mascota son obligatorios')->toArray());
         }
-        if ($FOTO_URL !== '') {
-            $esUrlValida = filter_var($FOTO_URL, FILTER_VALIDATE_URL);
-            $esHttp = in_array(strtolower(parse_url($FOTO_URL, PHP_URL_SCHEME) ?? ''), ['http', 'https'], true);
-            if ($esUrlValida === false || !$esHttp) {
-                return json_encode(Warning('La URL de la foto debe ser válida (http o https)')->toArray());
-            }
+
+        if ($CORREO_DUENNO !== '' && !filter_var($CORREO_DUENNO, FILTER_VALIDATE_EMAIL)) {
+            return json_encode(Warning('El correo del dueño debe ser válido')->toArray());
         }
+
+        $fotoResult = $this->manejarCargaFoto($this->getFiles('FOTO_ARCHIVO'), $FOTO_ACTUAL !== '' ? $FOTO_ACTUAL : null);
+        if ($fotoResult['error'] !== null) {
+            return json_encode(Warning($fotoResult['error'])->toArray());
+        }
+        $debeEliminarAnterior = false;
+        if (!empty($fotoResult['ruta']) && $fotoResult['ruta'] !== $FOTO_ACTUAL) {
+            $debeEliminarAnterior = true;
+            $FOTO_URL = $fotoResult['ruta'];
+        }
+
+        if (!$this->esFotoUrlValida($FOTO_URL)) {
+            return json_encode(Warning('La referencia de la foto no es válida')->toArray());
+        }
+
+        if ($FOTO_ACTUAL !== '' && $FOTO_URL === '') {
+            $debeEliminarAnterior = true;
+        }
+        if ($FOTO_ACTUAL !== '' && $FOTO_URL !== '' && $FOTO_URL !== $FOTO_ACTUAL && $this->esRutaInterna($FOTO_ACTUAL)) {
+            $debeEliminarAnterior = true;
+        }
+        if ($debeEliminarAnterior) {
+            $this->eliminarFotoLocal($FOTO_ACTUAL);
+        }
+
         $PM = model('Personas\\PersonasModel');
         $existe = $PM->select('ID_PERSONA')->where('ID_PERSONA', $ID_PERSONA)->toArray()->getFirstRow();
-        if (!$existe) {
-            $NOMBRE_DUENNO   = trim($_POST['NOMBRE_DUENNO']   ?? '');
-            $TELEFONO_DUENNO = trim($_POST['TELEFONO_DUENNO'] ?? '');
-            $CORREO_DUENNO   = trim($_POST['CORREO_DUENNO']   ?? '');
 
+        if (!$existe) {
             if ($NOMBRE_DUENNO === '' || $TELEFONO_DUENNO === '' || $CORREO_DUENNO === '') {
                 return json_encode(Warning('Debe completar los datos del dueño antes de registrar la mascota')->toArray());
             }
+
             $PM->insert([
                 'ID_PERSONA' => $ID_PERSONA,
                 'NOMBRE'     => $NOMBRE_DUENNO,
                 'TELEFONO'   => $TELEFONO_DUENNO,
                 'CORREO'     => $CORREO_DUENNO,
+                'ESTADO'     => 'ACT',
             ]);
+        } else {
+            $datosActualizar = [];
+            if ($NOMBRE_DUENNO !== '') {
+                $datosActualizar['NOMBRE'] = $NOMBRE_DUENNO;
+            }
+            if ($TELEFONO_DUENNO !== '') {
+                $datosActualizar['TELEFONO'] = $TELEFONO_DUENNO;
+            }
+            if ($CORREO_DUENNO !== '') {
+                $datosActualizar['CORREO'] = $CORREO_DUENNO;
+            }
+            if (!empty($datosActualizar)) {
+                $datosActualizar['ID_PERSONA'] = $ID_PERSONA;
+                $PM->update($datosActualizar);
+            }
         }
 
         $resp = model('Mascotas\\MascotasModel')->insert([
@@ -146,7 +186,10 @@ class Mascotas extends BaseController
             'ESTADO'         => 'ACT'
         ]);
 
-        if (!empty($resp)) return json_encode(Success('Mascota registrada correctamente')->toArray());
+        if (!empty($resp)) {
+            return json_encode(Success('Mascota registrada correctamente')->toArray());
+        }
+
         return json_encode(Warning('No ha sido posible registrar la mascota, intentalo de nuevo más tarde')->toArray());
     }
 
@@ -162,17 +205,33 @@ class Mascotas extends BaseController
         $ID_PERSONA     = trim($_POST['ID_PERSONA']     ?? '');
         $NOMBRE_MASCOTA = trim($_POST['NOMBRE_MASCOTA'] ?? '');
         $FOTO_URL       = trim($_POST['FOTO_URL']       ?? '');
+        $FOTO_ACTUAL    = trim($_POST['FOTO_ACTUAL']    ?? '');
         $ESTADO         = trim($_POST['ESTADO']         ?? '');
 
         if ($ID_MASCOTA <= 0 || $ID_PERSONA === '' || $NOMBRE_MASCOTA === '') {
             return json_encode(Warning('Campos incompletos')->toArray());
         }
-        if ($FOTO_URL !== '') {
-            $esUrlValida = filter_var($FOTO_URL, FILTER_VALIDATE_URL);
-            $esHttp = in_array(strtolower(parse_url($FOTO_URL, PHP_URL_SCHEME) ?? ''), ['http', 'https'], true);
-            if ($esUrlValida === false || !$esHttp) {
-                return json_encode(Warning('La URL de la foto debe ser válida (http o https)')->toArray());
-            }
+        $fotoResult = $this->manejarCargaFoto($this->getFiles('FOTO_ARCHIVO'), $FOTO_ACTUAL !== '' ? $FOTO_ACTUAL : null);
+        if ($fotoResult['error'] !== null) {
+            return json_encode(Warning($fotoResult['error'])->toArray());
+        }
+        $debeEliminarAnterior = false;
+        if (!empty($fotoResult['ruta']) && $fotoResult['ruta'] !== $FOTO_ACTUAL) {
+            $debeEliminarAnterior = true;
+            $FOTO_URL = $fotoResult['ruta'];
+        }
+
+        if (!$this->esFotoUrlValida($FOTO_URL)) {
+            return json_encode(Warning('La referencia de la foto no es válida')->toArray());
+        }
+        if ($FOTO_ACTUAL !== '' && $FOTO_URL === '') {
+            $debeEliminarAnterior = true;
+        }
+        if ($FOTO_ACTUAL !== '' && $FOTO_URL !== '' && $FOTO_URL !== $FOTO_ACTUAL && $this->esRutaInterna($FOTO_ACTUAL)) {
+            $debeEliminarAnterior = true;
+        }
+        if ($debeEliminarAnterior) {
+            $this->eliminarFotoLocal($FOTO_ACTUAL);
         }
         $data = [
             'ID_MASCOTA'     => $ID_MASCOTA,
@@ -185,7 +244,9 @@ class Mascotas extends BaseController
         }
 
         $resp = model('Mascotas\\MascotasModel')->update($data, $ID_MASCOTA);
-        if (!empty($resp)) return json_encode(Success('Mascota actualizada correctamente')->toArray());
+        if (!empty($resp)) {
+            return json_encode(Success('Mascota actualizada correctamente')->toArray());
+        }
         return json_encode(Warning('No han habido cambios en el registro')->toArray());
     }
 
@@ -203,5 +264,96 @@ class Mascotas extends BaseController
         $resp = model('Mascotas\\MascotasModel')->update(['ESTADO' => 'INC'], $ID_MASCOTA);
         if (!empty($resp)) return json_encode(Success('Mascota desactivada correctamente')->toArray());
         return json_encode(Warning('No ha sido posible desactivar el registro, intentalo de nuevo más tarde')->toArray());
+    }
+
+    private function manejarCargaFoto(?array $archivo, ?string $rutaActual = null): array
+    {
+        if (empty($archivo) || !isset($archivo['error']) || $archivo['error'] === UPLOAD_ERR_NO_FILE) {
+            return ['ruta' => $rutaActual, 'error' => null];
+        }
+
+        if ($archivo['error'] !== UPLOAD_ERR_OK) {
+            return ['ruta' => null, 'error' => 'No se pudo cargar la imagen seleccionada'];
+        }
+
+        $ext = strtolower(pathinfo($archivo['name'] ?? '', PATHINFO_EXTENSION));
+        $permitidas = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+        if (!in_array($ext, $permitidas, true)) {
+            return ['ruta' => null, 'error' => 'Formato de imagen no permitido'];
+        }
+
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $mime = $finfo ? finfo_file($finfo, $archivo['tmp_name']) : null;
+        if ($finfo) {
+            finfo_close($finfo);
+        }
+        $mimesPermitidos = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        if ($mime !== null && !in_array($mime, $mimesPermitidos, true)) {
+            return ['ruta' => null, 'error' => 'El archivo seleccionado no parece ser una imagen'];
+        }
+
+        $destDir = base_dir('public/uploads/mascotas');
+        if (!is_dir($destDir) && !mkdir($destDir, 0775, true) && !is_dir($destDir)) {
+            return ['ruta' => null, 'error' => 'No se pudo preparar el directorio de imágenes'];
+        }
+
+        $nombre = uniqid('mascota_', true) . '.' . $ext;
+        $destino = $destDir . DIRECTORY_SEPARATOR . $nombre;
+
+        if (!move_uploaded_file($archivo['tmp_name'], $destino)) {
+            return ['ruta' => null, 'error' => 'No se pudo guardar la imagen cargada'];
+        }
+
+        @chmod($destino, 0644);
+
+        if ($rutaActual) {
+            $rutaAnterior = base_dir('public/' . ltrim($rutaActual, '/'));
+            if (is_file($rutaAnterior)) {
+                @unlink($rutaAnterior);
+            }
+        }
+
+        return ['ruta' => 'uploads/mascotas/' . $nombre, 'error' => null];
+    }
+
+    private function esFotoUrlValida(?string $url): bool
+    {
+        if ($url === null || $url === '') {
+            return true;
+        }
+
+        $url = trim($url);
+        if ($url === '') {
+            return true;
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL)) {
+            $esHttp = in_array(strtolower(parse_url($url, PHP_URL_SCHEME) ?? ''), ['http', 'https'], true);
+            return $esHttp;
+        }
+
+        return $this->esRutaInterna($url);
+    }
+
+    private function esRutaInterna(?string $ruta): bool
+    {
+        if ($ruta === null || $ruta === '') {
+            return false;
+        }
+
+        $rutaNormalizada = ltrim($ruta, '/');
+        return strncmp($rutaNormalizada, 'uploads/mascotas/', strlen('uploads/mascotas/')) === 0;
+    }
+
+    private function eliminarFotoLocal(?string $ruta): void
+    {
+        if (!$this->esRutaInterna($ruta)) {
+            return;
+        }
+
+        $archivo = base_dir('public/' . ltrim((string)$ruta, '/'));
+        if (is_file($archivo)) {
+            @unlink($archivo);
+        }
     }
 }

--- a/mascotas/App/Controllers/Personas/Personas.php
+++ b/mascotas/App/Controllers/Personas/Personas.php
@@ -20,13 +20,14 @@ class Personas extends BaseController
             $NOMBRE     = trim($_GET['nombre']     ?? '');
             $TELEFONO   = trim($_GET['telefono']   ?? '');
             $CORREO     = trim($_GET['correo']     ?? '');
+            $ESTADO     = trim($_GET['estado']     ?? '');
             $ID_PERSONA = trim($_GET['idpersona']  ?? '');
 
             $PersonasModel = model('Personas\\PersonasModel');
 
             if ($ID_PERSONA !== '') {
                 $row = $PersonasModel
-                    ->select('ID_PERSONA', 'NOMBRE', 'TELEFONO', 'CORREO')
+                    ->select('ID_PERSONA', 'NOMBRE', 'TELEFONO', 'CORREO', 'ESTADO')
                     ->where('ID_PERSONA', $ID_PERSONA)
                     ->toArray()
                     ->getFirstRow();
@@ -55,10 +56,14 @@ class Personas extends BaseController
                 $where_list[] = 'CORREO LIKE ?';
                 $params[] = "%{$CORREO}%";
             }
+            if ($ESTADO !== '') {
+                $where_list[] = 'ESTADO = ?';
+                $params[] = $ESTADO;
+            }
 
             $where  = implode(' AND ', $where_list);
             $data = $PersonasModel->query(
-                "SELECT ID_PERSONA, NOMBRE, TELEFONO, CORREO
+                "SELECT ID_PERSONA, NOMBRE, TELEFONO, CORREO, ESTADO
                FROM tpersonas
               WHERE {$where}
            ORDER BY NOMBRE ASC",
@@ -78,7 +83,7 @@ class Personas extends BaseController
         if ($ced === '') return json_encode([]);
 
         $row = model('Personas\\PersonasModel')
-            ->select('ID_PERSONA', 'NOMBRE', 'TELEFONO', 'CORREO')
+            ->select('ID_PERSONA', 'NOMBRE', 'TELEFONO', 'CORREO', 'ESTADO')
             ->where('ID_PERSONA', $ced)
             ->toArray()
             ->getFirstRow();
@@ -121,6 +126,7 @@ class Personas extends BaseController
                 'NOMBRE'     => $NOMBRE,
                 'TELEFONO'   => $TELEFONO ?: null,
                 'CORREO'     => $CORREO   ?: null,
+                'ESTADO'     => 'ACT',
             ]);
         } catch (\Throwable $th) {
             log_message('error', 'Error al insertar persona: {error}', ['error' => $th->getMessage()]);
@@ -143,17 +149,23 @@ class Personas extends BaseController
         $NOMBRE     = trim($_POST['NOMBRE']     ?? '');
         $TELEFONO   = trim($_POST['TELEFONO']   ?? '');
         $CORREO     = trim($_POST['CORREO']     ?? '');
+        $ESTADO     = trim($_POST['ESTADO']     ?? '');
 
         if ($ID_PERSONA === '' || $NOMBRE === '') {
             return json_encode(Warning('Campos incompletos')->toArray());
         }
 
-        $resp = model('Personas\\PersonasModel')->update([
+        $data = [
             'ID_PERSONA' => $ID_PERSONA,
             'NOMBRE'     => $NOMBRE,
             'TELEFONO'   => $TELEFONO ?: null,
             'CORREO'     => $CORREO   ?: null,
-        ]);
+        ];
+        if ($ESTADO !== '') {
+            $data['ESTADO'] = $ESTADO;
+        }
+
+        $resp = model('Personas\\PersonasModel')->update($data);
 
         if (!empty($resp)) return json_encode(Success('Persona actualizada correctamente')->toArray());
         return json_encode(Warning('No han habido cambios en el registro')->toArray());

--- a/mascotas/App/Entities/Personas/PersonasEntity.php
+++ b/mascotas/App/Entities/Personas/PersonasEntity.php
@@ -30,6 +30,12 @@ class PersonasEntity extends Entity
         $this->attributes["CORREO"] = $v;
         return $this;
     }
+    /** @return self */
+    public function setESTADO($v)
+    {
+        $this->attributes["ESTADO"] = $v;
+        return $this;
+    }
 
     /** @return mixed */
     public function getIDPERSONA()
@@ -50,5 +56,10 @@ class PersonasEntity extends Entity
     public function getCORREO()
     {
         return $this->attributes["CORREO"] ?? null;
+    }
+    /** @return mixed */
+    public function getESTADO()
+    {
+        return $this->attributes["ESTADO"] ?? null;
     }
 }

--- a/mascotas/App/Models/Personas/PersonasModel.php
+++ b/mascotas/App/Models/Personas/PersonasModel.php
@@ -14,6 +14,7 @@ class PersonasModel extends Model
         "ID_PERSONA",
         "NOMBRE",
         "TELEFONO",
-        "CORREO"
+        "CORREO",
+        "ESTADO"
     ];
 }

--- a/mascotas/App/Views/mascotas/mascotas.php
+++ b/mascotas/App/Views/mascotas/mascotas.php
@@ -33,7 +33,7 @@ $permiso_editar   = validar_permiso("");
       <div class="col-12">
         <div class="card">
           <div class="card-header text-center" style="background: linear-gradient(to right, #20B2AA, #00FA9A, #20B2AA)">
-            <h3 class="card-title mb-0">Gestión de Mascotas</h3>
+            <h3 class="card-title mb-0">Gestión Integral de Mascotas y Propietarios</h3>
           </div>
           <div class="card-body">
             <div class="row mb-3" data-app-filtros>
@@ -46,16 +46,16 @@ $permiso_editar   = validar_permiso("");
               <div class="col-sm-4 col-lg-3">
                 <label class="w-100">
                   Cédula Dueño:
-                  <input type="text" class="form-control" placeholder="Cédula..." data-app-filtro-cedula />
+                  <input type="text" class="form-control" placeholder="Cédula..." data-app-filtro-cedula data-mask-cedula />
                 </label>
               </div>
               <div class="col-sm-4 col-lg-2">
                 <label class="w-100">
                   Estado:
                   <select class="form-select" data-app-filtro-estado>
-                    <option value="">Todos</option>
-                    <option value="ACT">Activo</option>
+                    <option value="ACT" selected>Activo</option>
                     <option value="INC">Inactivo</option>
+                    <option value="">Todos</option>
                   </select>
                 </label>
               </div>
@@ -87,7 +87,7 @@ $permiso_editar   = validar_permiso("");
           <h5 class="modal-title" id="mascotaModalLabel">Registrar / Editar Mascota</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
         </div>
-        <form id="FORM_MASCOTA" autocomplete="off">
+        <form id="FORM_MASCOTA" autocomplete="off" enctype="multipart/form-data">
           <div class="modal-body">
             <input type="hidden" name="ID_MASCOTA" />
             <div class="row g-3">
@@ -95,25 +95,25 @@ $permiso_editar   = validar_permiso("");
               <div class="col-sm-4">
                 <label class="w-100">
                   Dueño (cédula): <span class="text-danger">*</span>
-                  <input type="text" class="form-control" name="ID_PERSONA" required />
+                  <input type="text" class="form-control" name="ID_PERSONA" required data-mask-cedula />
                 </label>
               </div>
-              <div class="col-sm-4 d-none" data-duenno-field>
+              <div class="col-sm-4" data-duenno-field>
                 <label class="w-100">
                   Nombre del dueño: <span class="text-danger">*</span>
                   <input type="text" class="form-control" name="NOMBRE_DUENNO" />
                 </label>
               </div>
-              <div class="col-sm-4 d-none" data-duenno-field>
+              <div class="col-sm-4" data-duenno-field>
                 <label class="w-100">
                   Teléfono del dueño: <span class="text-danger">*</span>
                   <input type="text" class="form-control" name="TELEFONO_DUENNO" />
                 </label>
               </div>
-              <div class="col-sm-4 d-none" data-duenno-field>
+              <div class="col-sm-4" data-duenno-field>
                 <label class="w-100">
                   Correo del dueño: <span class="text-danger">*</span>
-                  <input type="email" class="form-control" name="CORREO_DUENNO" />
+                  <input type="email" class="form-control" name="CORREO_DUENNO" data-mask-email />
                 </label>
               </div>
               <div class="col-sm-4">
@@ -122,11 +122,23 @@ $permiso_editar   = validar_permiso("");
                   <input type="text" class="form-control" name="NOMBRE_MASCOTA" required />
                 </label>
               </div>
-              <div class="col-sm-12">
+              <div class="col-sm-6">
                 <label class="w-100">
-                  Foto URL:
-                  <input type="text" class="form-control" name="FOTO_URL" />
+                  Foto (URL externa):
+                  <input type="url" class="form-control" name="FOTO_URL" placeholder="https://..." data-app-foto-url />
                 </label>
+              </div>
+              <div class="col-sm-6">
+                <label class="w-100">
+                  Foto (archivo local):
+                  <input type="file" class="form-control" name="FOTO_ARCHIVO" accept="image/*" data-app-foto-archivo />
+                </label>
+              </div>
+              <div class="col-sm-12 text-center">
+                <input type="hidden" name="FOTO_ACTUAL" value="" data-app-foto-actual />
+                <div class="d-inline-block">
+                  <img src="" alt="Vista previa" class="img-thumbnail d-none" style="max-height: 140px;" data-app-foto-preview />
+                </div>
               </div>
               <div class="col-sm-4 d-none" data-app-estado-select-container>
                 <label class="w-100">
@@ -164,5 +176,6 @@ $permiso_editar   = validar_permiso("");
   };
 </script>
 <script src="<?= base_url('public/dist/datatables/datatables.min.js') ?>"></script>
+<script src="<?= base_url('public/js/form-masks.js') ?>"></script>
 <script src="<?= base_url('public/js/mascotas.js') ?>"></script>
 <?php endSection() ?>

--- a/mascotas/App/Views/personas/personas.php
+++ b/mascotas/App/Views/personas/personas.php
@@ -52,6 +52,16 @@
                   <input type="text" class="form-control" placeholder="Correo..." data-app-filtro-correo />
                 </label>
               </div>
+              <div class="col-sm-4 col-lg-3">
+                <label class="w-100">
+                  Estado:
+                  <select class="form-select" data-app-filtro-estado>
+                    <option value="ACT" selected>Activo</option>
+                    <option value="INC">Inactivo</option>
+                    <option value="">Todos</option>
+                  </select>
+                </label>
+              </div>
               <div class="col-sm-12 col-lg-3 d-flex align-items-end justify-content-end">
                 <button type="button" class="btn btn-primary btn-icon me-2" data-app-filtro-buscar>
                   <i class='bx bx-search-alt-2'></i> Buscar
@@ -71,6 +81,7 @@
                   <th>Nombre</th>
                   <th>Teléfono</th>
                   <th>Correo</th>
+                  <th>Estado</th>
                   <th>Acciones</th>
                 </tr>
               </thead>
@@ -99,7 +110,7 @@
             <div class="col-sm-4">
               <label class="w-100">
                 Cédula: <span class="text-danger">*</span>
-                <input type="text" class="form-control" name="ID_PERSONA" required />
+                <input type="text" class="form-control" name="ID_PERSONA" required data-mask-cedula />
               </label>
             </div>
             <div class="col-sm-8">
@@ -117,7 +128,7 @@
             <div class="col-sm-6">
               <label class="w-100">
                 Correo:
-                <input type="email" class="form-control" name="CORREO" />
+                <input type="email" class="form-control" name="CORREO" data-mask-email />
               </label>
             </div>
           </div>
@@ -135,5 +146,6 @@
 
 <?php section('foot') ?>
 <script src="<?= base_url('public/dist/datatables/datatables.min.js') ?>"></script>
+<script src="<?= base_url('public/js/form-masks.js') ?>"></script>
 <script src="<?= base_url('public/js/personas.js') ?>"></script>
 <?php endSection() ?>

--- a/mascotas/public/js/form-masks.js
+++ b/mascotas/public/js/form-masks.js
@@ -1,0 +1,110 @@
+(function (global) {
+  const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  const CEDULA_MAX_DIGITS = 11;
+
+  function formatCedula(value) {
+    const digits = (value || '').replace(/\D/g, '').slice(0, CEDULA_MAX_DIGITS);
+    const parts = [];
+
+    if (digits.length <= 3) {
+      parts.push(digits);
+    } else if (digits.length <= 10) {
+      parts.push(digits.slice(0, 3));
+      parts.push(digits.slice(3, 10));
+    } else {
+      parts.push(digits.slice(0, 3));
+      parts.push(digits.slice(3, 10));
+      parts.push(digits.slice(10));
+    }
+
+    if (parts.length === 0) {
+      return '';
+    }
+
+    if (parts.length === 1) {
+      return parts[0];
+    }
+
+    if (parts.length === 2) {
+      return `${parts[0]}-${parts[1]}`;
+    }
+
+    return `${parts[0]}-${parts[1]}-${parts[2]}`;
+  }
+
+  function isValidEmail(value) {
+    return EMAIL_REGEX.test(value);
+  }
+
+  function attachCedulaMask(input) {
+    if (!input || input.dataset.maskCedulaBound) {
+      return;
+    }
+
+    input.dataset.maskCedulaBound = '1';
+
+    input.addEventListener('input', function () {
+      const start = this.selectionStart;
+      const formatted = formatCedula(this.value);
+      this.value = formatted;
+      if (typeof start === 'number') {
+        this.setSelectionRange(this.value.length, this.value.length);
+      }
+    });
+
+    input.addEventListener('blur', function () {
+      this.value = formatCedula(this.value);
+    });
+  }
+
+  function attachEmailMask(input) {
+    if (!input || input.dataset.maskEmailBound) {
+      return;
+    }
+
+    input.dataset.maskEmailBound = '1';
+
+    input.addEventListener('input', function () {
+      const sanitized = (this.value || '').replace(/\s+/g, '');
+      if (sanitized !== this.value) {
+        this.value = sanitized;
+      }
+      if (this.classList.contains('is-invalid') && (this.value === '' || isValidEmail(this.value))) {
+        this.classList.remove('is-invalid');
+        this.setCustomValidity('');
+      }
+    });
+
+    input.addEventListener('blur', function () {
+      const valor = (this.value || '').trim();
+      if (valor === '' || isValidEmail(valor)) {
+        this.classList.remove('is-invalid');
+        this.setCustomValidity('');
+        this.value = valor;
+      } else {
+        this.classList.add('is-invalid');
+        this.setCustomValidity('Ingrese un correo válido');
+      }
+    });
+  }
+
+  function applyMasks(root = document) {
+    const scope = root instanceof Element ? root : document;
+    scope.querySelectorAll('[data-mask-cedula]').forEach(attachCedulaMask);
+    scope.querySelectorAll('[data-mask-email]').forEach(attachEmailMask);
+  }
+
+  const FormMasks = {
+    apply: applyMasks,
+    formatCedula,
+    isValidEmail
+  };
+
+  global.FormMasks = FormMasks;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => applyMasks());
+  } else {
+    applyMasks();
+  }
+})(window);

--- a/mascotas/public/js/mascotas.js
+++ b/mascotas/public/js/mascotas.js
@@ -2,17 +2,30 @@
   const formulario = $('#FORM_MASCOTA');
   const modal = $('#mascotaModal');
   const cedulaInput = formulario.find('[name="ID_PERSONA"]');
-  const duennoFields = formulario.find('[data-duenno-field]');
-  const duennoInputs = duennoFields.find('input');
+  const duennoInputs = formulario.find('[data-duenno-field] input');
   const estadoHiddenInput = formulario.find('[data-app-estado-hidden]');
   const estadoSelectContainer = formulario.find('[data-app-estado-select-container]');
   const estadoSelect = formulario.find('[data-app-estado-select]');
+  const fotoUrlInput = formulario.find('[data-app-foto-url]');
+  const fotoArchivoInput = formulario.find('[data-app-foto-archivo]');
+  const fotoPreview = formulario.find('[data-app-foto-preview]');
+  const fotoActualInput = formulario.find('[data-app-foto-actual]');
   let buscarPersonaTimeout = null;
   let buscarPersonaXHR = null;
+  let fotoObjectUrl = null;
 
-  function toggleDuennoFields(show) {
-    duennoFields.toggleClass('d-none', !show);
-    duennoInputs.prop('required', show);
+  function revokeFotoObjectUrl() {
+    if (fotoObjectUrl) {
+      URL.revokeObjectURL(fotoObjectUrl);
+      fotoObjectUrl = null;
+    }
+  }
+
+  function setCamposDuenoRequeridos(sonRequeridos) {
+    duennoInputs.each(function () {
+      $(this).prop('required', sonRequeridos);
+    });
+    formulario.data('persona-existe', !sonRequeridos);
   }
 
   function fillDuennoFields(values) {
@@ -28,13 +41,45 @@
     });
   }
 
+  function getPreviewUrl(valor) {
+    if (!valor) {
+      return null;
+    }
+
+    if (typeof isValidHttpUrl === 'function' && isValidHttpUrl(valor)) {
+      return valor;
+    }
+
+    if (/^https?:\/\//i.test(valor)) {
+      return valor;
+    }
+
+    return base_url(String(valor).replace(/^\/+/, ''));
+  }
+
+  function setPreview(url) {
+    if (url) {
+      fotoPreview.attr('src', url).removeClass('d-none');
+    } else {
+      fotoPreview.attr('src', '').addClass('d-none');
+    }
+  }
+
+  function resetFoto() {
+    revokeFotoObjectUrl();
+    fotoUrlInput.val('');
+    fotoArchivoInput.val('');
+    fotoActualInput.val('');
+    setPreview(null);
+  }
+
   function handlePersonaNotFound() {
     fillDuennoFields({
       NOMBRE_DUENNO: '',
       TELEFONO_DUENNO: '',
       CORREO_DUENNO: ''
     });
-    toggleDuennoFields(true);
+    setCamposDuenoRequeridos(true);
   }
 
   function handlePersonaFound(persona) {
@@ -43,7 +88,7 @@
       TELEFONO_DUENNO: persona.TELEFONO || '',
       CORREO_DUENNO: persona.CORREO || ''
     });
-    toggleDuennoFields(false);
+    setCamposDuenoRequeridos(false);
   }
 
   function consultarPersonaPorCedula(cedula) {
@@ -60,12 +105,7 @@
     }
 
     if (valor === '') {
-      fillDuennoFields({
-        NOMBRE_DUENNO: '',
-        TELEFONO_DUENNO: '',
-        CORREO_DUENNO: ''
-      });
-      toggleDuennoFields(false);
+      handlePersonaNotFound();
       return;
     }
 
@@ -93,32 +133,38 @@
         });
     }, 250);
   }
+
   function columnas() {
     return [
       { title: 'ID', data: 'ID_MASCOTA' },
       { title: 'Mascota', data: 'NOMBRE_MASCOTA' },
       { title: 'Dueño', data: 'DUENNO' },
-       {
+      {
         title: 'Foto',
         data: 'FOTO_URL',
         render: d => {
-          if (!d) return '';
-          if (typeof isValidHttpUrl === 'function' && isValidHttpUrl(d)) {
-            return `<img src="${d}" class="img-thumbnail" style="width:40px;height:40px;">`;
+          const url = getPreviewUrl(d);
+          if (!url) {
+            return '';
           }
-          return '';
+          return `<img src="${url}" class="img-thumbnail" style="width:40px;height:40px;">`;
         }
       },
-      { title: 'Estado', data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' },
+      { title: 'Estado', data: 'ESTADO', render: d => (d === 'ACT' ? 'ACTIVO' : 'INACTIVO') },
       {
-        title: 'Acciones', data: null, orderable: false, searchable: false, render: (_, __, row) => `
+        title: 'Acciones',
+        data: null,
+        orderable: false,
+        searchable: false,
+        render: (_, __, row) => `
         <button type="button" class="btn btn-primary btn-sm" data-editar data-id="${row.ID_MASCOTA}">
           <i class='bx bx-edit-alt'></i>
         </button>
         <button type="button" class="btn btn-danger btn-sm" data-eliminar data-id="${row.ID_MASCOTA}">
           <i class='bx bx-trash'></i>
         </button>
-      ` }
+      `
+      }
     ];
   }
 
@@ -135,30 +181,90 @@
     }
   }
 
-  $(document).on('click', '[data-bs-target="#mascotaModal"]', function () {
+  function prepararFormularioAlta() {
     formulario[0].reset();
     formulario.removeData('editar');
     formulario.find('[name="ID_MASCOTA"]').val('');
+    formulario.removeData('persona-existe');
     bloquearEstado(true);
     modal.find('.modal-title').text('Registrar Mascota');
-    toggleDuennoFields(false);
+    resetFoto();
+    setCamposDuenoRequeridos(true);
     fillDuennoFields({
       NOMBRE_DUENNO: '',
       TELEFONO_DUENNO: '',
       CORREO_DUENNO: ''
     });
+    if (typeof FormMasks !== 'undefined') {
+      FormMasks.apply(formulario[0]);
+    }
+  }
+
+  $(document).on('click', '[data-bs-target="#mascotaModal"]', prepararFormularioAlta);
+
+  function actualizarPreviewDesdeUrl() {
+    const valor = (fotoUrlInput.val() || '').trim();
+    if (valor === '') {
+      if (!fotoArchivoInput.length || !fotoArchivoInput[0].files.length) {
+        setPreview(fotoActualInput.val() ? getPreviewUrl(fotoActualInput.val()) : null);
+      }
+      return;
+    }
+    revokeFotoObjectUrl();
+    setPreview(getPreviewUrl(valor));
+  }
+
+  fotoUrlInput.on('input', function () {
+    const valor = (this.value || '').trim();
+    if (valor !== '') {
+      fotoArchivoInput.val('');
+    }
+    actualizarPreviewDesdeUrl();
+  });
+
+  fotoUrlInput.on('blur', actualizarPreviewDesdeUrl);
+
+  fotoArchivoInput.on('change', function () {
+    revokeFotoObjectUrl();
+    const file = this.files && this.files[0];
+    if (file) {
+      fotoUrlInput.val('');
+      fotoObjectUrl = URL.createObjectURL(file);
+      setPreview(fotoObjectUrl);
+    } else if (fotoActualInput.val()) {
+      setPreview(getPreviewUrl(fotoActualInput.val()));
+    } else {
+      setPreview(null);
+    }
   });
 
   function guardarMascota(ev) {
     ev.preventDefault();
+
+    if (!formulario[0].checkValidity()) {
+      formulario[0].reportValidity();
+      return;
+    }
+
     const $btn = formulario.find('button[type="submit"]').prop('disabled', true);
     const url = formulario.data('editar') ? URL_MASCOTAS.editar : URL_MASCOTAS.guardar;
+    const datos = new FormData(formulario[0]);
 
-    $.ajax({ url, method: 'POST', data: formulario.serialize(), dataType: 'json' })
+    $.ajax({
+      url,
+      method: 'POST',
+      data: datos,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
       .done(resp => {
         if (resp && resp.TIPO) {
           alerta[capitalize(resp.TIPO)](resp.MENSAJE).show();
-          if (resp.TIPO === 'SUCCESS') { modal.modal('hide'); tabla.ajax.reload(null, false); }
+          if (resp.TIPO === 'SUCCESS') {
+            modal.modal('hide');
+            tabla.ajax.reload(null, false);
+          }
         } else {
           alerta.Warning('Respuesta inválida del servidor').show();
         }
@@ -170,18 +276,19 @@
   function editarMascota() {
     const id = $(this).data('id');
     $.getJSON(URL_MASCOTAS.obtener, { idmascota: id }, data => {
-      formulario[0].reset();
-      Object.entries(data || {}).forEach(([k, v]) => { formulario.find(`[name="${k}"]`).val(v); });
+      prepararFormularioAlta();
+      Object.entries(data || {}).forEach(([k, v]) => {
+        formulario.find(`[name="${k}"]`).val(v);
+      });
       formulario.data('editar', true);
       bloquearEstado(false);
+      fotoActualInput.val(data && data.FOTO_URL ? data.FOTO_URL : '');
+      if (data && data.FOTO_URL) {
+        setPreview(getPreviewUrl(data.FOTO_URL));
+        fotoUrlInput.val(data.FOTO_URL);
+      }
       modal.find('.modal-title').text('Editar Mascota');
       modal.modal('show');
-      toggleDuennoFields(false);
-      fillDuennoFields({
-        NOMBRE_DUENNO: '',
-        TELEFONO_DUENNO: '',
-        CORREO_DUENNO: ''
-      });
       consultarPersonaPorCedula(formulario.find('[name="ID_PERSONA"]').val());
     });
   }
@@ -249,7 +356,14 @@
     dom: "<'row'<'col-sm-6'l><'col-sm-6 text-end'f>>rt<'row'<'col-sm-6'i><'col-sm-6'p>>"
   });
 
-  $('[data-app-filtro-buscar]').on('click', function () { tabla.ajax.reload(); });
+  $('[data-app-filtro-buscar]').on('click', function () {
+    tabla.ajax.reload();
+  });
+
+  $('[data-app-filtro-estado]').on('change', function () {
+    tabla.ajax.reload();
+  });
+
   formulario.on('submit', guardarMascota);
   $('#tmascotas').on('click', '[data-editar]', editarMascota);
   $('#tmascotas').on('click', '[data-eliminar]', eliminarMascota);

--- a/mascotas/public/js/personas.js
+++ b/mascotas/public/js/personas.js
@@ -46,6 +46,9 @@
         formulario.find(`[name="${k}"]`).val(v);
       });
       formulario.data('editar', true);
+      if (typeof FormMasks !== 'undefined') {
+        FormMasks.apply(formulario[0]);
+      }
     });
   }
 
@@ -73,6 +76,7 @@
         d.nombre = $f.find('[data-app-filtro-nombre]').val() || '';
         d.telefono = $f.find('[data-app-filtro-telefono]').val() || '';
         d.correo = $f.find('[data-app-filtro-correo]').val() || '';
+        d.estado = $f.find('[data-app-filtro-estado]').val() || '';
       }
     },
     columns: [
@@ -80,6 +84,7 @@
       { data: 'NOMBRE' },
       { data: 'TELEFONO' },
       { data: 'CORREO' },
+      { data: 'ESTADO', render: d => (d === 'ACT' ? 'ACTIVO' : 'INACTIVO') },
       { data: null, render: renderAcciones, orderable: false, searchable: false }
     ],
     language: {
@@ -97,6 +102,10 @@
   });
 
   $('[data-app-filtro-buscar]').on('click', function () {
+    tabla.ajax.reload();
+  });
+
+  $('[data-app-filtro-estado]').on('change', function () {
     tabla.ajax.reload();
   });
 


### PR DESCRIPTION
## Summary
- Revamp the mascota registration modal to always show owner details, support local photo uploads with preview, and default list filters to active records for a more descriptive management experience. 
- Implement server-side image handling that validates uploads, stores files under public/uploads/mascotas, cleans up old assets, and creates or updates owner records with basic validation. 
- Introduce shared JavaScript masks for cédula and email fields, expose ESTADO filtering in personas, and persist estado data through the model, entity, controller, and UI layers.

## Testing
- `php -l App/Controllers/Mascotas/Mascotas.php`
- `php -l App/Controllers/Personas/Personas.php`
- `php -l App/Entities/Personas/PersonasEntity.php`
- `php -l App/Models/Personas/PersonasModel.php`


------
https://chatgpt.com/codex/tasks/task_e_68d46e41ca00832c87adad8e51ac6b85