### PR TITLE
Refine personas y mascotas sin filtros y con inactivación

### DIFF
--- a/mascotas/App/Controllers/Personas/Personas.php
+++ b/mascotas/App/Controllers/Personas/Personas.php
@@ -208,28 +208,27 @@ class Personas extends BaseController
             return json_encode(Warning('Solicitud inválida')->setPROCESS('personas.remover')->toArray());
         }
 
-        $dbUsuarios = model('Usuarios\\UsuariosModel')
+        $PersonasModel = model('Personas\\PersonasModel');
+
+        $persona = $PersonasModel
+            ->select('ID_PERSONA', 'ESTADO')
             ->where('ID_PERSONA', $ID_PERSONA)
             ->limit(1)
             ->toArray()
             ->getFirstRow();
-        if ($dbUsuarios !== null) {
-            return json_encode(Warning('No es posible eliminar: la persona tiene un usuario asociado')->setPROCESS('personas.remover')->toArray());
+
+        if ($persona === null) {
+            return json_encode(Warning('No se encontró la persona solicitada')->setPROCESS('personas.remover')->toArray());
         }
 
-        $dbMascotas = model('Mascotas\\MascotasModel')
-            ->where('ID_PERSONA', $ID_PERSONA)
-            ->limit(1)
-            ->toArray()
-            ->getFirstRow();
-        if ($dbMascotas !== null) {
-            return json_encode(Warning('No es posible eliminar: la persona tiene mascotas asociadas')->setPROCESS('personas.remover')->toArray());
+        if (($persona['ESTADO'] ?? '') === 'INC') {
+            return json_encode(Warning('La persona ya se encuentra inactiva')->setPROCESS('personas.remover')->toArray());
         }
 
-        $ok = model('Personas\\PersonasModel')->delete($ID_PERSONA);
+        $ok = $PersonasModel->update(['ESTADO' => 'INC'], $ID_PERSONA);
         if (!empty($ok)) {
-            return json_encode(Success('Persona eliminada correctamente')->setPROCESS('personas.remover')->toArray());
+            return json_encode(Success('Persona inactivada correctamente')->setPROCESS('personas.remover')->toArray());
         }
-        return json_encode(Warning('No ha sido posible eliminar el registro')->setPROCESS('personas.remover')->toArray());
+        return json_encode(Warning('No ha sido posible inactivar el registro')->setPROCESS('personas.remover')->toArray());
     }
 }

--- a/mascotas/App/Views/mascotas/mascotas.php
+++ b/mascotas/App/Views/mascotas/mascotas.php
@@ -31,47 +31,46 @@ $permiso_editar   = validar_permiso("");
   <div class="container-fluid">
     <div class="row mt-4">
       <div class="col-12">
-        <div class="card">
-          <div class="card-header text-center" style="background: linear-gradient(to right, #20B2AA, #00FA9A, #20B2AA)">
-            <h3 class="card-title mb-0">Gestión Integral de Mascotas y Dueños Registrados</h3>
+        <div class="card shadow-lg border-0">
+          <div class="card-header py-3" style="background: linear-gradient(to right, #20B2AA, #00FA9A, #20B2AA)">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+              <div class="d-flex align-items-center gap-3">
+                <span class="badge bg-white text-success rounded-circle p-3 shadow-sm">
+                  <i class='bx bxs-dog fs-4'></i>
+                </span>
+                <div class="text-white">
+                  <h3 class="card-title mb-1">Gestión Integral de Mascotas y Dueños Registrados</h3>
+                  <small class="text-white-50">Administra la información de cada mascota y su familia desde un solo panel.</small>
+                </div>
+              </div>
+              <?php if ($permiso_guardar): ?>
+                <button type="button" class="btn btn-light text-success fw-semibold" data-bs-toggle="modal" data-bs-target="#mascotaModal">
+                  <i class="fas fa-plus me-1"></i> Nueva Mascota
+                </button>
+              <?php endif ?>
+            </div>
           </div>
           <div class="card-body">
-            <div class="row mb-3" data-app-filtros>
-              <div class="col-sm-4 col-lg-3">
-                <label class="w-100">
-                  Nombre Mascota:
-                  <input type="text" class="form-control" placeholder="Nombre..." data-app-filtro-nombre />
-                </label>
-              </div>
-              <div class="col-sm-4 col-lg-3">
-                <label class="w-100">
-                  Cédula Dueño:
-                  <input type="text" class="form-control" placeholder="Cédula..." data-app-filtro-cedula />
-                </label>
-              </div>
-              <div class="col-sm-4 col-lg-2">
-                <label class="w-100">
-                  Estado:
-                  <select class="form-select" data-app-filtro-estado>
-                    <option value="">Todos</option>
-                    <option value="ACT" selected>Activo</option>
-                    <option value="INC">Inactivo</option>
-                  </select>
-                </label>
-              </div>
-              <div class="col-sm-12 col-lg-4 d-flex align-items-end justify-content-end">
-                <button type="button" class="btn btn-primary btn-icon me-2" data-app-filtro-buscar>
-                  <i class='bx bx-search-alt-2'></i> Buscar
-                </button>
-                <?php if ($permiso_guardar): ?>
-                  <button type="button" class="btn btn-success btn-icon" data-bs-toggle="modal" data-bs-target="#mascotaModal">
-                    <i class="fas fa-plus"></i> Nueva Mascota
-                  </button>
-                <?php endif ?>
-              </div>
+            <div class="mb-4">
+              <h5 class="mb-1 text-primary"><i class='bx bx-bone me-2'></i>Resumen de registros</h5>
+              <p class="text-muted mb-0">Consulta el estado de cada mascota y realiza actualizaciones en pocos clics.</p>
             </div>
 
-            <table id="tmascotas" class="table table-hover w-100"></table>
+            <div class="table-responsive shadow-sm rounded">
+              <table id="tmascotas" class="table table-hover align-middle mb-0">
+                <thead class="table-light text-muted">
+                  <tr>
+                    <th>ID</th>
+                    <th>Mascota</th>
+                    <th>Dueño</th>
+                    <th>Foto</th>
+                    <th>Estado</th>
+                    <th class="text-center">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
@@ -178,5 +177,5 @@ $permiso_editar   = validar_permiso("");
 </script>
 <script src="<?= base_url('public/dist/datatables/datatables.min.js') ?>"></script>
 <script src="<?= base_url('public/js/form-masks.js') ?>"></script>
-<script src="<?= base_url('public/js/mascotas.js') ?>"></script>
+<script src="<?= base_url('public/developments/mascotas/mascotas.js') ?>"></script>
 <?php endSection() ?>

--- a/mascotas/App/Views/personas/personas.php
+++ b/mascotas/App/Views/personas/personas.php
@@ -28,65 +28,46 @@
   <div class="container-fluid">
     <div class="row mt-4">
       <div class="col-12">
-        <div class="card">
-          <div class="card-header text-center" style="background: linear-gradient(to right, #20B2AA, #00FA9A, #20B2AA)">
-            <h3 class="card-title mb-0">Gestión Detallada de Personas y Contactos</h3>
+        <div class="card shadow-lg border-0">
+          <div class="card-header py-3" style="background: linear-gradient(to right, #20B2AA, #00FA9A, #20B2AA)">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+              <div class="d-flex align-items-center gap-3">
+                <span class="badge bg-white text-success rounded-circle p-3 shadow-sm">
+                  <i class='bx bxs-user-detail fs-4'></i>
+                </span>
+                <div class="text-white">
+                  <h3 class="card-title mb-1">Gestión Detallada de Personas y Contactos</h3>
+                  <small class="text-white-50">Supervisa los registros y mantén la información siempre actualizada.</small>
+                </div>
+              </div>
+              <?php if ($permiso_guardar): ?>
+                <button type="button" class="btn btn-light text-success fw-semibold" data-bs-toggle="modal" data-bs-target="#personaCrearModal">
+                  <i class="fas fa-plus me-1"></i> Nueva Persona
+                </button>
+              <?php endif ?>
+            </div>
           </div>
           <div class="card-body">
-            <div class="row mb-3" data-app-filtros>
-              <div class="col-sm-4 col-lg-3">
-                <label class="w-100">
-                  Nombre:
-                  <input type="text" class="form-control" placeholder="Nombre..." data-app-filtro-nombre />
-                </label>
-              </div>
-              <div class="col-sm-4 col-lg-3">
-                <label class="w-100">
-                  Teléfono:
-                  <input type="text" class="form-control" placeholder="Teléfono..." data-app-filtro-telefono />
-                </label>
-              </div>
-              <div class="col-sm-4 col-lg-3">
-                <label class="w-100">
-                  Correo:
-                  <input type="text" class="form-control" placeholder="Correo..." data-app-filtro-correo />
-                </label>
-              </div>
-              <div class="col-sm-4 col-lg-2">
-                <label class="w-100">
-                  Estado:
-                  <select class="form-select" data-app-filtro-estado>
-                    <option value="">Todos</option>
-                    <option value="ACT" selected>Activo</option>
-                    <option value="INC">Inactivo</option>
-                  </select>
-                </label>
-              </div>
-              <div class="col-sm-12 col-lg-3 d-flex align-items-end justify-content-end">
-                <button type="button" class="btn btn-primary btn-icon me-2" data-app-filtro-buscar>
-                  <i class='bx bx-search-alt-2'></i> Buscar
-                </button>
-                <?php if ($permiso_guardar): ?>
-               <button type="button" class="btn btn-success btn-icon" data-bs-toggle="modal" data-bs-target="#personaCrearModal">
-                  <i class="fas fa-plus"></i> Nueva Persona
-                </button>
-                <?php endif ?>
-              </div>
+            <div class="mb-4">
+              <h5 class="mb-1 text-primary"><i class='bx bx-group me-2'></i>Listado general</h5>
+              <p class="text-muted mb-0">Consulta rápidamente a las personas registradas y actualiza sus datos en cuestión de segundos.</p>
             </div>
 
-            <table id="tpersonas" class="table table-hover w-100">
-              <thead class="table-secondary text-muted">
-                <tr>
-                  <th>Cédula</th>
-                  <th>Nombre</th>
-                  <th>Teléfono</th>
-                  <th>Correo</th>
-                  <th>Estado</th>
-                  <th>Acciones</th>
-                </tr>
-              </thead>
-              <tbody></tbody>
-            </table>
+            <div class="table-responsive shadow-sm rounded">
+              <table id="tpersonas" class="table table-hover align-middle mb-0">
+                <thead class="table-light text-muted">
+                  <tr>
+                    <th>Cédula</th>
+                    <th>Nombre</th>
+                    <th>Teléfono</th>
+                    <th>Correo</th>
+                    <th>Estado</th>
+                    <th class="text-center">Acciones</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
 
           </div>
         </div>
@@ -205,5 +186,5 @@
 <?php section('foot') ?>
 <script src="<?= base_url('public/dist/datatables/datatables.min.js') ?>"></script>
 <script src="<?= base_url('public/js/form-masks.js') ?>"></script>
-<script src="<?= base_url('public/js/personas.js') ?>"></script>
+<script src="<?= base_url('public/developments/personas/personas.js') ?>"></script>
 <?php endSection() ?>

--- a/mascotas/public/developments/mascotas/mascotas.js
+++ b/mascotas/public/developments/mascotas/mascotas.js
@@ -124,13 +124,15 @@
       },
       { title: 'Estado', data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' },
       {
-        title: 'Acciones', data: null, orderable: false, searchable: false, render: (_, __, row) => `
-        <button type="button" class="btn btn-primary btn-sm" data-editar data-id="${row.ID_MASCOTA}">
-          <i class='bx bx-edit-alt'></i>
-        </button>
-        <button type="button" class="btn btn-danger btn-sm" data-eliminar data-id="${row.ID_MASCOTA}">
-          <i class='bx bx-trash'></i>
-        </button>
+        title: 'Acciones', data: null, orderable: false, searchable: false, className: 'text-center', render: (_, __, row) => `
+        <div class="d-flex justify-content-center gap-2">
+          <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_MASCOTA}">
+            <i class='bx bx-edit-alt'></i>
+          </button>
+          <button type="button" class="btn btn-outline-danger btn-sm rounded-pill" data-eliminar data-id="${row.ID_MASCOTA}">
+            <i class='bx bx-block'></i>
+          </button>
+        </div>
       ` }
     ];
   }
@@ -219,7 +221,7 @@
 
   function eliminarMascota() {
     const id = $(this).data('id');
-    confirmar.Warning('¿Desea eliminar el registro?', 'Atención').then(resp => {
+    confirmar.Warning('¿Desea inactivar esta mascota?', 'Confirmación requerida').then(resp => {
       if (!resp) return;
       $.post(URL_MASCOTAS.eliminar, { idmascota: id }, r => {
         const tipo = (r && (r.type || r.TIPO) || '').toString().toUpperCase();
@@ -230,7 +232,7 @@
         } else {
           alerta.Warning('Respuesta inválida del servidor').show();
         }
-      }, 'json').fail(() => alerta.Danger('No se pudo eliminar').show());
+      }, 'json').fail(() => alerta.Danger('No se pudo inactivar').show());
     });
   }
 
@@ -242,12 +244,6 @@
         if (Array.isArray(resp.data)) return resp.data;
         if (resp.data && Array.isArray(resp.data.data)) return resp.data.data;
         return resp.data && typeof resp.data === 'object' ? Object.values(resp.data) : [];
-      },
-      data: function (d) {
-        const $f = $('[data-app-filtros]');
-        d.nombre = $f.find('[data-app-filtro-nombre]').val() || '';
-        d.idpersona = $f.find('[data-app-filtro-cedula]').val() || '';
-        d.estado = $f.find('[data-app-filtro-estado]').val() || '';
       },
       error: function (xhr) {
         let mensaje = 'Ocurrió un error al obtener el listado de mascotas.';
@@ -287,7 +283,6 @@
     dom: "<'row'<'col-sm-6'l><'col-sm-6 text-end'f>>rt<'row'<'col-sm-6'i><'col-sm-6'p>>"
   });
 
-  $('[data-app-filtro-buscar]').on('click', function () { tabla.ajax.reload(); });
   formulario.on('submit', guardarMascota);
   $('#tmascotas').on('click', '[data-editar]', editarMascota);
   $('#tmascotas').on('click', '[data-eliminar]', eliminarMascota);

--- a/mascotas/public/developments/personas/personas.js
+++ b/mascotas/public/developments/personas/personas.js
@@ -31,12 +31,14 @@
 
   function renderAcciones(_, __, row) {
     return `
-      <button type="button" class="btn btn-primary btn-sm" data-editar data-id="${row.ID_PERSONA}" data-bs-toggle="modal" data-bs-target="#personaEditarModal">
-        <i class='bx bx-edit-alt'></i>
-      </button>
-      <button type="button" class="btn btn-danger btn-sm" data-eliminar data-id="${row.ID_PERSONA}">
-        <i class='bx bx-trash'></i>
-      </button>
+      <div class="d-flex justify-content-center gap-2">
+        <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_PERSONA}" data-bs-toggle="modal" data-bs-target="#personaEditarModal">
+          <i class='bx bx-edit-alt'></i>
+        </button>
+        <button type="button" class="btn btn-outline-danger btn-sm rounded-pill" data-eliminar data-id="${row.ID_PERSONA}">
+          <i class='bx bx-user-x'></i>
+        </button>
+      </div>
     `;
   }
 
@@ -112,12 +114,12 @@
 
   function eliminarPersona() {
     const id = $(this).data('id');
-    confirmar.Warning('¿Desea eliminar el registro?', 'Atención').then(resp => {
+    confirmar.Warning('¿Desea inactivar a esta persona?', 'Confirmación requerida').then(resp => {
       if (!resp) return;
       $.post(base_url('personas/eliminar'), { idpersona: id }, r => {
-        const tipo = mostrarAlerta(r, 'No se pudo eliminar el registro.');
+        const tipo = mostrarAlerta(r, 'No se pudo inactivar el registro.');
         if (tipo === 'SUCCESS') tabla.ajax.reload(null, false);
-      }, 'json').fail(() => alerta.Danger('No se pudo eliminar').show());
+      }, 'json').fail(() => alerta.Danger('No se pudo inactivar').show());
     });
   }
 
@@ -129,13 +131,6 @@
         if (Array.isArray(resp.data)) return resp.data;
         if (resp.data && Array.isArray(resp.data.data)) return resp.data.data;
         return resp.data && typeof resp.data === 'object' ? Object.values(resp.data) : [];
-      },
-      data: function (d) {
-        const $f = $('[data-app-filtros]');
-        d.nombre = $f.find('[data-app-filtro-nombre]').val() || '';
-        d.telefono = $f.find('[data-app-filtro-telefono]').val() || '';
-        d.correo = $f.find('[data-app-filtro-correo]').val() || '';
-        d.estado = $f.find('[data-app-filtro-estado]').val() || '';
       }
     },
     columns: [
@@ -144,7 +139,7 @@
       { data: 'TELEFONO' },
       { data: 'CORREO' },
       { data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' },
-      { data: null, render: renderAcciones, orderable: false, searchable: false }
+      { data: null, render: renderAcciones, orderable: false, searchable: false, className: 'text-center' }
     ],
     language: {
       lengthMenu: "_MENU_ por página",
@@ -158,10 +153,6 @@
       search: "Buscar:"
     },
     dom: "<'row'<'col-sm-6'l><'col-sm-6 text-end'f>>" + "rt" + "<'row'<'col-sm-6'i><'col-sm-6'p>>"
-  });
-
-  $('[data-app-filtro-buscar]').on('click', function () {
-    tabla.ajax.reload();
   });
 
   if (formularioCrear.length) formularioCrear.on('submit', guardarPersona);


### PR DESCRIPTION
## Summary
- refrescar las vistas de personas y mascotas con tarjetas estilizadas, encabezados informativos y tablas responsivas sin filtros adicionales
- cargar los nuevos scripts reubicados para personas y mascotas y ajustar los botones de acción a un estilo con píldoras centradas
- permitir que la acción de eliminación de personas marque el registro como inactivo y alinear los mensajes de confirmación con la nueva lógica de inactivación

## Testing
- php -l mascotas/App/Controllers/Personas/Personas.php

------
https://chatgpt.com/codex/tasks/task_e_68d4cff8bd30832c8ffda06b6481f5ba