### PR TITLE
Improve owner validation and live lookup for pets module

### DIFF
--- a/mascotas/App/Controllers/Personas/Personas.php
+++ b/mascotas/App/Controllers/Personas/Personas.php
@@ -142,6 +142,16 @@ class Personas extends BaseController
                 $params
             );
 
+            if (is_object($data)) {
+                if (method_exists($data, 'getResultArray')) {
+                    $data = $data->getResultArray();
+                } elseif (method_exists($data, 'getResult')) {
+                    $data = $data->getResult('array');
+                } else {
+                    $data = (array) $data;
+                }
+            }
+
             if (!is_array($data)) {
                 $data = [];
             }

--- a/mascotas/App/Views/mascotas/mascotas.php
+++ b/mascotas/App/Views/mascotas/mascotas.php
@@ -127,6 +127,9 @@ $permiso_editar   = validar_permiso("");
                   <input type="email" class="form-control" name="CORREO_DUENNO" data-mask-email />
                 </label>
               </div>
+              <div class="col-sm-12">
+                <small class="form-text d-none" data-duenno-state></small>
+              </div>
               <div class="col-sm-4">
                 <label class="w-100">
                   Nombre Mascota: <span class="text-danger">*</span>

--- a/mascotas/public/developments/personas/personas.js
+++ b/mascotas/public/developments/personas/personas.js
@@ -45,6 +45,10 @@
   function guardarPersona(ev) {
     ev.preventDefault();
     if (!formularioCrear.length) return;
+    if (formularioCrear[0].checkValidity && !formularioCrear[0].checkValidity()) {
+      formularioCrear[0].reportValidity && formularioCrear[0].reportValidity();
+      return;
+    }
     const $btn = formularioCrear.find('button[type="submit"]').prop('disabled', true);
 
     $.ajax({


### PR DESCRIPTION
## Summary
- validate incoming owner data in Mascotas::guardar, surface detailed errors and reuse existing owners when available
- add owner status hint and stricter client-side validation for the pet form, including dynamic highlighting during cedula lookups
- ensure the persona creation form performs HTML5 validation before submitting via AJAX
- normalize the personas listing query response so the DataTable receives a proper JSON array

## Testing
- php -l App/Controllers/Mascotas/Mascotas.php
- php -l App/Views/mascotas/mascotas.php
- php -l App/Controllers/Personas/Personas.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f3a62158832caa6c7a33689e06a2