### PR TITLE
Remove personas estado handling and align UI alerts

### DIFF
--- a/mascotas/App/Controllers/Mascotas/Mascotas.php
+++ b/mascotas/App/Controllers/Mascotas/Mascotas.php
@@ -18,7 +18,7 @@ class Mascotas extends BaseController
         }
 
         $resultado = model('Personas\\PersonasModel')->query(
-            "SELECT ID_PERSONA, NOMBRE, TELEFONO, CORREO, ESTADO
+            "SELECT ID_PERSONA, NOMBRE, TELEFONO, CORREO
                FROM tpersonas
               WHERE REPLACE(ID_PERSONA, '-', '') = ?
               LIMIT 1",
@@ -276,7 +276,6 @@ class Mascotas extends BaseController
                     'NOMBRE'     => $NOMBRE_DUENNO,
                     'TELEFONO'   => $TELEFONO_DUENNO,
                     'CORREO'     => $CORREO_DUENNO,
-                    'ESTADO'     => 'ACT',
                 ]);
 
                 if ($insertPersona === false) {

--- a/mascotas/App/Entities/Personas/PersonasEntity.php
+++ b/mascotas/App/Entities/Personas/PersonasEntity.php
@@ -30,13 +30,6 @@ class PersonasEntity extends Entity
         $this->attributes["CORREO"] = $v;
         return $this;
     }
-    /** @return self */
-    public function setESTADO($v)
-    {
-        $this->attributes["ESTADO"] = $v;
-        return $this;
-    }
-
     /** @return mixed */
     public function getIDPERSONA()
     {
@@ -56,10 +49,5 @@ class PersonasEntity extends Entity
     public function getCORREO()
     {
         return $this->attributes["CORREO"] ?? null;
-    }
-    /** @return mixed */
-    public function getESTADO()
-    {
-        return $this->attributes["ESTADO"] ?? null;
     }
 }

--- a/mascotas/App/Models/Personas/PersonasModel.php
+++ b/mascotas/App/Models/Personas/PersonasModel.php
@@ -14,7 +14,6 @@ class PersonasModel extends Model
         "ID_PERSONA",
         "NOMBRE",
         "TELEFONO",
-        "CORREO",
-        "ESTADO"
+        "CORREO"
     ];
 }

--- a/mascotas/App/Views/personas/personas.php
+++ b/mascotas/App/Views/personas/personas.php
@@ -58,7 +58,6 @@
                     <th>Nombre</th>
                     <th>Teléfono</th>
                     <th>Correo</th>
-                    <th>Estado</th>
                     <th class="text-center">Acciones</th>
                   </tr>
                 </thead>
@@ -108,9 +107,6 @@
                 <input type="email" class="form-control" name="CORREO" data-mask-email />
               </label>
             </div>
-            <div class="col-sm-12">
-              <input type="hidden" name="ESTADO" value="ACT" />
-            </div>
           </div>
         </div>
         <div class="modal-footer">
@@ -156,15 +152,6 @@
               <label class="w-100">
                 Correo:
                 <input type="email" class="form-control" name="CORREO" data-mask-email />
-              </label>
-            </div>
-            <div class="col-sm-6">
-              <label class="w-100">
-                Estado:
-                <select class="form-select" name="ESTADO">
-                  <option value="ACT">Activo</option>
-                  <option value="INC">Inactivo</option>
-                </select>
               </label>
             </div>
           </div>

--- a/mascotas/public/developments/personas/personas.js
+++ b/mascotas/public/developments/personas/personas.js
@@ -7,6 +7,53 @@
   const modalCrear = hasBootstrap && modalCrearEl ? bootstrap.Modal.getOrCreateInstance(modalCrearEl) : null;
   const modalEditar = hasBootstrap && modalEditarEl ? bootstrap.Modal.getOrCreateInstance(modalEditarEl) : null;
 
+  function capitalizarInterno(valor) {
+    if (typeof valor !== 'string' || valor.trim() === '') {
+      return '';
+    }
+    if (typeof capitalize === 'function') {
+      return capitalize(valor);
+    }
+    const lower = valor.toLowerCase();
+    return lower.charAt(0).toUpperCase() + lower.slice(1);
+  }
+
+  function invocarAlerta(tipoDeseado, mensaje, tipoRespaldo = 'info') {
+    if (typeof alerta === 'undefined') {
+      console.warn(mensaje);
+      return null;
+    }
+
+    const candidatos = [];
+    if (tipoDeseado) {
+      const tipoLower = tipoDeseado.toLowerCase();
+      candidatos.push(tipoLower, capitalizarInterno(tipoLower), tipoDeseado);
+    }
+    if (tipoRespaldo) {
+      const respaldoLower = tipoRespaldo.toLowerCase();
+      candidatos.push(respaldoLower, capitalizarInterno(respaldoLower), tipoRespaldo);
+    }
+
+    for (const clave of candidatos) {
+      if (clave && typeof alerta[clave] === 'function') {
+        try {
+          return alerta[clave](mensaje);
+        } catch (error) {
+          console.error('No se pudo invocar la alerta:', error);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function mostrarPeligro(mensaje) {
+    const instancia = invocarAlerta('danger', mensaje, 'danger');
+    if (instancia && typeof instancia.show === 'function') {
+      instancia.show();
+    }
+  }
+
   function obtenerTipo(resp) {
     return (resp && (resp.type || resp.TIPO) || '').toString().toUpperCase();
   }
@@ -21,10 +68,9 @@
   function mostrarAlerta(resp, fallback) {
     const tipo = obtenerTipo(resp);
     const mensaje = obtenerMensaje(resp, fallback);
-    if (tipo && alerta[capitalize(tipo)]) {
-      alerta[capitalize(tipo)](mensaje).show();
-    } else {
-      alerta.Info(mensaje).show();
+    const instancia = invocarAlerta(tipo, mensaje);
+    if (instancia && typeof instancia.show === 'function') {
+      instancia.show();
     }
     return tipo;
   }
@@ -65,7 +111,7 @@
           tabla.ajax.reload(null, false);
         }
       })
-      .fail(() => alerta.Danger('No se pudo procesar la solicitud').show())
+      .fail(() => mostrarPeligro('No se pudo procesar la solicitud'))
       .always(() => $btn.prop('disabled', false));
   }
 
@@ -87,7 +133,7 @@
           tabla.ajax.reload(null, false);
         }
       })
-      .fail(() => alerta.Danger('No se pudo procesar la solicitud').show())
+      .fail(() => mostrarPeligro('No se pudo procesar la solicitud'))
       .always(() => $btn.prop('disabled', false));
   }
 
@@ -112,18 +158,18 @@
         if (modalEditar) modalEditar.show();
       })
       .fail(() => {
-        alerta.Danger('No se pudo obtener la información de la persona').show();
+        mostrarPeligro('No se pudo obtener la información de la persona');
       });
   }
 
   function eliminarPersona() {
     const id = $(this).data('id');
-    confirmar.Warning('¿Desea inactivar a esta persona?', 'Confirmación requerida').then(resp => {
+    confirmar.Warning('¿Desea eliminar a esta persona?', 'Confirmación requerida').then(resp => {
       if (!resp) return;
       $.post(base_url('personas/eliminar'), { idpersona: id }, r => {
-        const tipo = mostrarAlerta(r, 'No se pudo inactivar el registro.');
+        const tipo = mostrarAlerta(r, 'No se pudo eliminar el registro.');
         if (tipo === 'SUCCESS') tabla.ajax.reload(null, false);
-      }, 'json').fail(() => alerta.Danger('No se pudo inactivar').show());
+      }, 'json').fail(() => mostrarPeligro('No se pudo eliminar'));
     });
   }
 
@@ -152,10 +198,7 @@
           }
         }
 
-        if (typeof alerta !== 'undefined' && alerta.Danger) {
-          alerta.Danger(mensaje).show();
-        }
-
+        mostrarPeligro(mensaje);
         console.error(xhr.responseText || mensaje);
       }
     },
@@ -164,7 +207,6 @@
       { data: 'NOMBRE' },
       { data: 'TELEFONO' },
       { data: 'CORREO' },
-      { data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' },
       { data: null, render: renderAcciones, orderable: false, searchable: false, className: 'text-center' }
     ],
     language: {


### PR DESCRIPTION
## Summary
- Stop querying or storing personas ESTADO data, delete personas only when they have no pets, and guard against accidental removal of linked owners.
- Ensure mascotas controller no longer attempts to seed ESTADO when auto-creating a persona record.
- Refresh personas front-end alerts to use the new danger() helper, update confirmation copy, and gracefully handle non-JSON error responses.

## Testing
- php -l App/Controllers/Personas/Personas.php
- php -l App/Controllers/Mascotas/Mascotas.php
- php -l App/Models/Personas/PersonasModel.php
- php -l App/Entities/Personas/PersonasEntity.php

------
https://chatgpt.com/codex/tasks/task_e_68d50d1baf9c832c8d78942430bca381