### PR TITLE
Corrige registro de mascotas y mejora interfaces

### DIFF
--- a/mascotas/App/Views/mascotas/mascotas.php
+++ b/mascotas/App/Views/mascotas/mascotas.php
@@ -57,12 +57,12 @@ $permiso_editar   = validar_permiso("");
               <table id="tmascotas" class="table table-hover align-middle mb-0">
                 <thead class="table-light text-muted">
                   <tr>
+                    <th class="text-center">Acciones</th>
                     <th>ID</th>
                     <th>Mascota</th>
                     <th>Dueño</th>
                     <th>Foto</th>
                     <th>Estado</th>
-                    <th class="text-center">Acciones</th>
                   </tr>
                 </thead>
                 <tbody></tbody>

--- a/mascotas/App/Views/personas/personas.php
+++ b/mascotas/App/Views/personas/personas.php
@@ -54,11 +54,11 @@
               <table id="tpersonas" class="table table-hover align-middle mb-0">
                 <thead class="table-light text-muted">
                   <tr>
+                    <th class="text-center">Acciones</th>
                     <th>Cédula</th>
                     <th>Nombre</th>
                     <th>Teléfono</th>
                     <th>Correo</th>
-                    <th class="text-center">Acciones</th>
                   </tr>
                 </thead>
                 <tbody></tbody>

--- a/mascotas/public/developments/mascotas/mascotas.js
+++ b/mascotas/public/developments/mascotas/mascotas.js
@@ -171,6 +171,23 @@
   }
   function columnas() {
     return [
+      {
+        title: 'Acciones',
+        data: null,
+        orderable: false,
+        searchable: false,
+        className: 'text-center',
+        render: (_, __, row) => `
+        <div class="d-flex justify-content-center gap-2">
+          <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_MASCOTA}" title="Editar información de la mascota">
+            <i class='bx bx-edit-alt'></i>
+          </button>
+          <button type="button" class="btn btn-outline-danger btn-sm rounded-pill" data-eliminar data-id="${row.ID_MASCOTA}" title="Inactivar esta mascota">
+            <i class='bx bx-block'></i>
+          </button>
+        </div>
+      `
+      },
       { title: 'ID', data: 'ID_MASCOTA' },
       { title: 'Mascota', data: 'NOMBRE_MASCOTA' },
       { title: 'Dueño', data: 'DUENNO' },
@@ -188,18 +205,7 @@
           `;
         }
       },
-      { title: 'Estado', data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' },
-      {
-        title: 'Acciones', data: null, orderable: false, searchable: false, className: 'text-center', render: (_, __, row) => `
-        <div class="d-flex justify-content-center gap-2">
-          <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_MASCOTA}">
-            <i class='bx bx-edit-alt'></i>
-          </button>
-          <button type="button" class="btn btn-outline-danger btn-sm rounded-pill" data-eliminar data-id="${row.ID_MASCOTA}">
-            <i class='bx bx-block'></i>
-          </button>
-        </div>
-      ` }
+      { title: 'Estado', data: 'ESTADO', render: d => d === 'ACT' ? 'ACTIVO' : 'INACTIVO' }
     ];
   }
 
@@ -271,7 +277,7 @@
           tabla.ajax.reload(null, false);
         }
       })
-      .fail(() => alerta.Danger('No se pudo procesar la solicitud').show())
+      .fail(() => alerta.Danger('No se pudo completar el registro de la mascota. Inténtalo nuevamente.').show())
       .always(() => $btn.prop('disabled', false));
   }
 
@@ -304,7 +310,7 @@
 
   function eliminarMascota() {
     const id = $(this).data('id');
-    confirmar.Warning('¿Desea inactivar esta mascota?', 'Confirmación requerida').then(resp => {
+    confirmar.Warning('¿Deseas inactivar esta mascota? Podrás activarla nuevamente cuando lo necesites.', 'Confirmación requerida').then(resp => {
       if (!resp) return;
       $.post(URL_MASCOTAS.eliminar, { idmascota: id }, r => {
         const tipo = (r && (r.type || r.TIPO) || '').toString().toUpperCase();
@@ -313,9 +319,9 @@
           alerta[capitalize(tipo)](mensaje).show();
           if (tipo === 'SUCCESS') tabla.ajax.reload(null, false);
         } else {
-          alerta.Warning('Respuesta inválida del servidor').show();
+          alerta.Warning('No se recibió una respuesta válida del servidor. Inténtalo nuevamente.').show();
         }
-      }, 'json').fail(() => alerta.Danger('No se pudo inactivar').show());
+      }, 'json').fail(() => alerta.Danger('No se pudo inactivar la mascota. Inténtalo nuevamente.').show());
     });
   }
 

--- a/mascotas/public/developments/personas/personas.js
+++ b/mascotas/public/developments/personas/personas.js
@@ -78,11 +78,8 @@
   function renderAcciones(_, __, row) {
     return `
       <div class="d-flex justify-content-center gap-2">
-        <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_PERSONA}" data-bs-toggle="modal" data-bs-target="#personaEditarModal">
+        <button type="button" class="btn btn-outline-primary btn-sm rounded-pill" data-editar data-id="${row.ID_PERSONA}" data-bs-toggle="modal" data-bs-target="#personaEditarModal" title="Editar información de la persona">
           <i class='bx bx-edit-alt'></i>
-        </button>
-        <button type="button" class="btn btn-outline-danger btn-sm rounded-pill" data-eliminar data-id="${row.ID_PERSONA}">
-          <i class='bx bx-user-x'></i>
         </button>
       </div>
     `;
@@ -111,7 +108,7 @@
           tabla.ajax.reload(null, false);
         }
       })
-      .fail(() => mostrarPeligro('No se pudo procesar la solicitud'))
+      .fail(() => mostrarPeligro('No se pudo completar el registro. Inténtalo nuevamente.'))
       .always(() => $btn.prop('disabled', false));
   }
 
@@ -133,7 +130,7 @@
           tabla.ajax.reload(null, false);
         }
       })
-      .fail(() => mostrarPeligro('No se pudo procesar la solicitud'))
+      .fail(() => mostrarPeligro('No se pudo completar la actualización. Inténtalo nuevamente.'))
       .always(() => $btn.prop('disabled', false));
   }
 
@@ -158,19 +155,8 @@
         if (modalEditar) modalEditar.show();
       })
       .fail(() => {
-        mostrarPeligro('No se pudo obtener la información de la persona');
+        mostrarPeligro('No se pudo obtener la información de la persona seleccionada.');
       });
-  }
-
-  function eliminarPersona() {
-    const id = $(this).data('id');
-    confirmar.Warning('¿Desea eliminar a esta persona?', 'Confirmación requerida').then(resp => {
-      if (!resp) return;
-      $.post(base_url('personas/eliminar'), { idpersona: id }, r => {
-        const tipo = mostrarAlerta(r, 'No se pudo eliminar el registro.');
-        if (tipo === 'SUCCESS') tabla.ajax.reload(null, false);
-      }, 'json').fail(() => mostrarPeligro('No se pudo eliminar'));
-    });
   }
 
   const tabla = $('#tpersonas').DataTable({
@@ -203,11 +189,11 @@
       }
     },
     columns: [
+      { data: null, render: renderAcciones, orderable: false, searchable: false, className: 'text-center' },
       { data: 'ID_PERSONA' },
       { data: 'NOMBRE' },
       { data: 'TELEFONO' },
-      { data: 'CORREO' },
-      { data: null, render: renderAcciones, orderable: false, searchable: false, className: 'text-center' }
+      { data: 'CORREO' }
     ],
     language: {
       lengthMenu: "_MENU_ por página",
@@ -226,5 +212,4 @@
   if (formularioCrear.length) formularioCrear.on('submit', guardarPersona);
   if (formularioEditar.length) formularioEditar.on('submit', actualizarPersona);
   if (formularioEditar.length) $('#tpersonas').on('click', '[data-editar]', editarPersona);
-  $('#tpersonas').on('click', '[data-eliminar]', eliminarPersona);
 })();


### PR DESCRIPTION
## Resumen
- Corrige el manejo de fotografías de mascotas utilizando `base_dir`, agrega mensajes de error más descriptivos y normaliza las respuestas JSON del registro de mascotas.
- Ajusta las tablas de mascotas y personas para mostrar la columna de acciones al inicio y mejora los textos mostrados al usuario.
- Elimina la opción de eliminar personas desde la interfaz y actualiza los mensajes de confirmación y error asociados.

## Pruebas
- `php -l mascotas/App/Controllers/Mascotas/Mascotas.php`
- `php -l mascotas/App/Views/mascotas/mascotas.php`
- `php -l mascotas/App/Views/personas/personas.php`


------
https://chatgpt.com/codex/tasks/task_e_68d51252fb14832c9fd60a85e96ed363